### PR TITLE
Explicitly use all files in pack.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,23 +21,24 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [ "*" ],
   "main": "lib/Ckb.js",
   "module": "lib-es/Ckb.js",
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/hw-transport": "^5.9.0",
-    "bip32-path": "0.4.2",
     "bech32": "1.1.4",
+    "bip32-path": "0.4.2",
     "blake2b-wasm": "2.1.0"
   },
   "devDependencies": {
-    "flow-bin": "^0.118.0",
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.0.2",
     "babel-preset-env": "^1.7.0",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
+    "flow-bin": "^0.118.0",
     "flow-copy-source": "^2.0.8",
     "flow-typed": "^2.6.1"
   },


### PR DESCRIPTION
Previously, without an explicit "files" field in package.json,
preparing the package for release with "yarn pack" would result in
some compiled files in lib/ going missing.

This should fix our reported missing files issue.