### PR TITLE
use the ckb2021 address format

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/hw-transport": "^5.9.0",
-    "bech32": "1.1.4",
+    "bech32": "2.0.0",
     "bip32-path": "0.4.2",
     "blake2b-wasm": "2.1.0"
   },

--- a/src/Ckb.js
+++ b/src/Ckb.js
@@ -10,6 +10,33 @@ import { bech32m } from "bech32";
 // The bech32m encoding limit should be increased
 const BECH32_LIMIT = 1023;
 
+// APDU command constants
+const CLA = 0x80;                  // Command class (Nervos app)
+
+// Instruction codes
+// defined at https://github.com/LedgerHQ/app-nervos/blob/develop/src/apdu.h#L21
+const INS_GET_CONFIG = 0x00;       // Get app configuration
+const INS_GET_WALLET_ID = 0x01;    // Get wallet identifier
+const INS_GET_PUBLIC_KEY = 0x02;   // Get wallet public key
+const INS_SIGN_TX = 0x03;          // Sign transaction
+const INS_GET_EXTENDED_PUBKEY = 0x04; // Get extended public key
+const INS_SIGN_MSG = 0x06;         // Sign message
+const INS_GET_APP_HASH = 0x09;     // Get app hash
+
+// Parameter 1 (P1) values
+// defined at https://github.com/LedgerHQ/app-nervos/blob/develop/src/apdu_sign.c#L968
+const P1_INIT = 0x00;              // Initialization
+const P1_CONTINUE = 0x01;          // Continuation
+const P1_LAST_MARKER = 0x80;       // Last chunk flag
+const P1_FINAL = 0x81;             // Final chunk (CONTINUE | LAST_MARKER)
+
+// Parameter 2 (P2) values
+const P2_DEFAULT = 0x00;           // Default P2 value
+
+// Other constants
+const MAX_APDU_SIZE = 230;         // Maximum data size per APDU
+const SIGNATURE_SIZE = 65;         // Size of the returned signature (r, s, v)
+
 /**
  * Nervos API
  *
@@ -48,10 +75,6 @@ export default class Ckb {
   async getWalletPublicKey(path: string, testnet: boolean): Promise<string> {
     const bipPath = BIPPath.fromString(path).toPathArray();
 
-    const cla = 0x80;
-    const ins = 0x02;
-    const p1 = 0x00;
-    const p2 = 0x00;
     const data = Buffer.alloc(1 + bipPath.length * 4);
 
     data.writeUInt8(bipPath.length, 0);
@@ -59,7 +82,7 @@ export default class Ckb {
       data.writeUInt32BE(segment, 1 + index * 4);
     });
 
-    const response = await this.transport.send(cla, ins, p1, p2, data);
+    const response = await this.transport.send(CLA, INS_GET_PUBLIC_KEY, P1_INIT, P2_DEFAULT, data);
 
     const publicKeyLength = response[0];
     const publicKey = response.slice(1, 1 + publicKeyLength);
@@ -293,8 +316,8 @@ export default class Ckb {
     version: string,
     hash: string,
   }> {
-    const response1 = await this.transport.send(0x80, 0x00, 0x00, 0x00);
-    const response2 = await this.transport.send(0x80, 0x09, 0x00, 0x00);
+    const response1 = await this.transport.send(CLA, INS_GET_CONFIG, P1_INIT, P2_DEFAULT);
+    const response2 = await this.transport.send(CLA, INS_GET_APP_HASH, P1_INIT, P2_DEFAULT);
     return {
       version: "" + response1[0] + "." + response1[1] + "." + response1[2],
       hash: response2.slice(0, -3).toString("latin1") // last 3 bytes should be 0x009000
@@ -311,43 +334,93 @@ export default class Ckb {
    * "0x69c46b6dd072a2693378ef4f5f35dcd82f826dc1fdcc891255db5870f54b06e6"
    */
   async getWalletId(): Promise<string> {
-    const response = await this.transport.send(0x80, 0x01, 0x00, 0x00);
+    const response = await this.transport.send(
+      CLA, 
+      INS_GET_WALLET_ID, 
+      P1_INIT, 
+      P2_DEFAULT
+    );
 
     const result = response.slice(0, 32).toString("hex");
 
     return result;
   }
 
+  /**
+   * Sign a message with the Ledger device using a specific BIP32 path
+   * 
+   * @param {string} path - BIP32 path to derive the key for signing (e.g. "44'/309'/0'/0/0")
+   * @param {string} rawMsgHex - Hex string of the message to be signed
+   * @param {boolean} displayHex - Whether to display the message as hex (true) or as text (false) on the device
+   * @return {string} - Hex string of the signature (65 bytes: r, s, v components)
+   * @example
+   * const signature = await ckb.signMessage("44'/309'/0'/0/0", "48656c6c6f20776f726c64", false);
+   */
   async signMessage(
     path: string,
     rawMsgHex: string,
     displayHex: bool
   ): Promise<string> {
+    // Convert BIP32 path string to array of integers
     const bipPath = BIPPath.fromString(path).toPathArray();
+    
+    // Prepend "Nervos Message:" to prevent message signing from being used to sign transactions
+    // This is a security measure known as "domain separation"
     const magicBytes = Buffer.from("Nervos Message:");
     const rawMsg = Buffer.concat([magicBytes, Buffer.from(rawMsgHex, "hex")]);
 
-    //Init apdu
+    // Step 1: Send initialization APDU with BIP path and display preferences
+    // Format: [displayHex(1), pathLength(1), path(4*pathLength)]
     let rawPath = Buffer.alloc(1 + 1 + bipPath.length * 4);
-    rawPath.writeInt8(displayHex, 0);
-    rawPath.writeInt8(bipPath.length, 1);
+    rawPath.writeInt8(displayHex, 0);                // First byte: display as hex flag
+    rawPath.writeInt8(bipPath.length, 1);            // Second byte: number of path components
     bipPath.forEach((segment, index) => {
-      rawPath.writeUInt32BE(segment, 2 + index * 4);
+      rawPath.writeUInt32BE(segment, 2 + index * 4); // Following bytes: path components (4 bytes each)
     });
-    await this.transport.send(0x80, 0x06, 0x00, 0x00, rawPath);
+    
+    // Send initialization command to the device
+    await this.transport.send(
+      CLA, 
+      INS_SIGN_MSG, 
+      P1_INIT, 
+      P2_DEFAULT, 
+      rawPath
+    );
 
-    // Msg Chunking
-    const maxApduSize = 230;
-    let txFullChunks = Math.floor(rawMsg.length / maxApduSize);
-    for (let i = 0; i < txFullChunks; i++) {
-      let data = rawMsg.slice(i*maxApduSize, (i+1)*maxApduSize);
-      await this.transport.send(0x80, 0x06, 0x01, 0x00, data);
+    // Step 2: Send message data in chunks due to APDU size limitations
+    const fullChunksCount = Math.floor(rawMsg.length / MAX_APDU_SIZE);
+    
+    // Send all complete chunks except the last one
+    for (let i = 0; i < fullChunksCount; i++) {
+      const chunkStart = i * MAX_APDU_SIZE;
+      const chunkEnd = (i + 1) * MAX_APDU_SIZE;
+      const chunkData = rawMsg.slice(chunkStart, chunkEnd);
+      
+      // Send continuation APDU with chunk data
+      await this.transport.send(
+        CLA, 
+        INS_SIGN_MSG, 
+        P1_CONTINUE, 
+        P2_DEFAULT, 
+        chunkData
+      );
     }
 
-    let lastOffset = Math.floor(rawMsg.length / maxApduSize) * maxApduSize;
-    let lastData = rawMsg.slice(lastOffset, lastOffset+maxApduSize);
-    let response = await this.transport.send(0x80, 0x06, 0x81, 0x00, lastData);
-    return response.slice(0,65).toString("hex");
+    // Step 3: Send the final chunk and receive the signature
+    const lastChunkOffset = fullChunksCount * MAX_APDU_SIZE;
+    const lastChunkData = rawMsg.slice(lastChunkOffset);
+    
+    // Send final chunk with the "last chunk" flag set
+    const response = await this.transport.send(
+      CLA, 
+      INS_SIGN_MSG, 
+      P1_FINAL,     // 0x81 = 0x01 (continue) | 0x80 (last chunk)
+      P2_DEFAULT, 
+      lastChunkData
+    );
+    
+    // Extract and return the signature (first 65 bytes of the response)
+    return response.slice(0, SIGNATURE_SIZE).toString("hex");
   }
 
 }

--- a/src/Ckb.js
+++ b/src/Ckb.js
@@ -73,7 +73,7 @@ export default class Ckb {
 
     const addr_contents: number[] = [
       // CKB 2021 address full format prefix
-      ...0x00,
+      0x00,
       // SECP256K1_BLAKE160 code hash
       ...[
         155, 215, 224, 111,  62, 207, 75,

--- a/src/Ckb.js
+++ b/src/Ckb.js
@@ -89,7 +89,8 @@ export default class Ckb {
     ];
     const addr = bech32m.encode(
       testnet ? "ckt" : "ckb",
-      bech32m.toWords(addr_contents)
+      bech32m.toWords(addr_contents),
+      1023
     );
 
     return {

--- a/src/Ckb.js
+++ b/src/Ckb.js
@@ -4,7 +4,7 @@ import type Transport from "@ledgerhq/hw-transport";
 import BIPPath from "bip32-path";
 import * as blockchain from "./annotated";
 import Blake2b from "blake2b-wasm";
-import * as bech32 from "bech32";
+import { bech32m } from "bech32";
 
 /**
  * Nervos API
@@ -71,12 +71,25 @@ export default class Ckb {
         .subarray(0, 20)
     );
 
-    const addr_contents = Buffer.alloc(22);
-    addr_contents.fill("0100", 0, 2, "hex");
-    addr_contents.fill(lockArg, 2, 22);
-    const addr = bech32.encode(
+    const addr_contents: number[] = [
+      // CKB 2021 address full format prefix
+      ...0x00,
+      // SECP256K1_BLAKE160 code hash
+      ...[
+        155, 215, 224, 111,  62, 207, 75,
+        224, 242, 252, 210,  24, 139, 35,
+        241, 185, 252, 200, 142,  93, 75,
+        101, 168,  99, 123,  23, 114, 59,
+        189, 163, 204, 232
+      ],
+      // SECP256K1_BLAKE160 hash type
+      0b0000000_1,
+      // lock args
+      ...lockArg
+    ];
+    const addr = bech32m.encode(
       testnet ? "ckt" : "ckb",
-      bech32.toWords(addr_contents)
+      bech32m.toWords(addr_contents)
     );
 
     return {

--- a/src/Ckb.js
+++ b/src/Ckb.js
@@ -83,7 +83,7 @@ export default class Ckb {
         189, 163, 204, 232
       ],
       // SECP256K1_BLAKE160 hash type
-      0b0000000_1,
+      0b00000001,
       // lock args
       ...lockArg
     ];

--- a/src/Ckb.js
+++ b/src/Ckb.js
@@ -6,6 +6,10 @@ import * as blockchain from "./annotated";
 import Blake2b from "blake2b-wasm";
 import { bech32m } from "bech32";
 
+// CKB address is longer than the longest Bitcoin address
+// The bech32m encoding limit should be increased
+const BECH32_LIMIT = 1023;
+
 /**
  * Nervos API
  *
@@ -90,7 +94,7 @@ export default class Ckb {
     const addr = bech32m.encode(
       testnet ? "ckt" : "ckb",
       bech32m.toWords(addr_contents),
-      1023
+      BECH32_LIMIT
     );
 
     return {

--- a/src/annotated.js
+++ b/src/annotated.js
@@ -80,11 +80,20 @@ function fromStringEnum(val) {
   case "string":
     switch(val.toLowerCase()) {
     case "code":
-    case "data":
       return 0;
     case "dep_group":
-    case "type":
       return 1;
+    // The last 1 bit represents using type hash.
+    // If the last bit is 0, it indicates using code hash to locate the contract code. 
+    // The first 7 bits prepresent the VM version to run the contract code.
+    case "type":
+      return 0b0000000_1;
+    case "data":
+      return 0b0000000_0;
+    case "data1":
+      return 0b0000001_0;
+    case "data2":
+      return 0b0000010_0;
     default:
     throw new Error("Not a valid byte representation: "+val);
     }

--- a/tests/Ckb.test.js
+++ b/tests/Ckb.test.js
@@ -280,3 +280,24 @@ test("ckb.signMessage", async () => {
 
   expect(result).toEqual("be13155a7f6815c715f7dcdc797038e1d5e03621a716ce9aafa2265408ab36833b262855b79e28c99a43ed8dc046577e3cd7445e0f5a8c2a8ebcb7092c53141d029000");
 });
+
+test("ckb.signMessageHash", async () => {
+  const Transport = createTransportReplayer(
+    RecordStore.fromString(`
+    => 800700001600018000002c80000135800000000000000100000000
+    <= 00009000
+    => 800781009bd9f5a5389a5fa929e9c4cca2d5c81a462c3b8f0ef65a95c9fa252a1c8f1b0f
+    <= 3045022100a8cb47a4c3e6e6e5b19e4e73b916b4c6ba5f5817e6222a05f8c4a35d8b61071d022032c3f5e156b3d0d3a21f0c9c97c949c4cb8f4193d171d4fe4cdf62ae0bf3137d019000
+    `)
+  );
+
+  const transport = await Transport.open();
+
+  const ckb = new Ckb(transport);
+
+  // Test with a sample 32-byte message hash
+  const messageHash = "9bd9f5a5389a5fa929e9c4cca2d5c81a462c3b8f0ef65a95c9fa252a1c8f1b0f";
+  const result = await ckb.signMessageHash("m/44'/309'/0'/1/0", messageHash, true);
+
+  expect(result).toEqual("3045022100a8cb47a4c3e6e6e5b19e4e73b916b4c6ba5f5817e6222a05f8c4a35d8b61071d022032c3f5e156b3d0d3a21f0c9c97c949c4cb8f4193d171d4fe4cdf62ae0bf3137d019000");
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,10 +1168,10 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-bech32@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
-  integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
+bech32@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bech32/-/bech32-2.0.0.tgz#078d3686535075c8c79709f054b1b226a133b355"
+  integrity sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==
 
 before-after-hook@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
- Move APDU command constants from static class properties to module-level constants
- Improve code readability by removing class name prefixes from constant references
- Update all method implementations to use the module-level constants
- Maintain comprehensive documentation for all constants
- Organize constants into logical groups (command class, instruction codes, parameters)